### PR TITLE
New CryptoDotCom Transaction History CSV Import feature.

### DIFF
--- a/AltFuture.BusinessLogicLayer/AltFuture.BusinessLogicLayer.csproj
+++ b/AltFuture.BusinessLogicLayer/AltFuture.BusinessLogicLayer.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Models\ExchangeTransactions\CryptoDotComTransactionHistoryDto.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="CsvHelper" Version="30.0.1" />
   </ItemGroup>
@@ -14,6 +18,10 @@
   <ItemGroup>
     <ProjectReference Include="..\AltFuture.DataAccessLayer\AltFuture.DataAccessLayer.csproj" />
     <ProjectReference Include="..\AltFuture.MarketDataConsumer\AltFuture.MarketDataConsumer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="AutoMapper\CryptoDotComTransactionHitoryToTransaction\" />
   </ItemGroup>
 
 </Project>

--- a/AltFuture.BusinessLogicLayer/AutoMapper/CoinbaseTransactionHistoryToTransaction/CoinbaseCryptoResolver.cs
+++ b/AltFuture.BusinessLogicLayer/AutoMapper/CoinbaseTransactionHistoryToTransaction/CoinbaseCryptoResolver.cs
@@ -3,7 +3,7 @@ using AutoMapper;
 using AltFuture.DataAccessLayer.Interfaces.Services;
 using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
 
-namespace AltFuture.BusinessLogicLayer.AutoMapper.CoinbaseAssetToCryptoResolver
+namespace AltFuture.BusinessLogicLayer.AutoMapper.CoinbaseTransactionHistoryToTransaction
 {
     internal class CoinbaseCryptoResolver : IValueResolver<CoinbaseTransactionHistoryDto, Transaction, int>
     {

--- a/AltFuture.BusinessLogicLayer/AutoMapper/CoinbaseTransactionHistoryToTransaction/CoinbaseTransactionHistoryProfile.cs
+++ b/AltFuture.BusinessLogicLayer/AutoMapper/CoinbaseTransactionHistoryToTransaction/CoinbaseTransactionHistoryProfile.cs
@@ -1,5 +1,4 @@
-﻿using AltFuture.BusinessLogicLayer.AutoMapper.CoinbaseAssetToCryptoResolver;
-using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
+﻿using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
 using AltFuture.DataAccessLayer.Data.Enums;
 using AltFuture.DataAccessLayer.Models;
 using AutoMapper;

--- a/AltFuture.BusinessLogicLayer/AutoMapper/Transactions/CryptoDotComBuyTransactionHitoryProfile.cs
+++ b/AltFuture.BusinessLogicLayer/AutoMapper/Transactions/CryptoDotComBuyTransactionHitoryProfile.cs
@@ -1,0 +1,27 @@
+﻿using AltFuture.BusinessLogicLayer.AutoMapper.Transactions.Resolvers;
+using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
+using AltFuture.DataAccessLayer.Data.Enums;
+using AltFuture.DataAccessLayer.Models;
+using AutoMapper;
+
+namespace AltFuture.BusinessLogicLayer.AutoMapper.Transactions
+{
+    public class CryptoDotComBuyTransactionHitoryProfile : Profile
+    {
+        public CryptoDotComBuyTransactionHitoryProfile()
+        {
+            int appUserId = 1;
+            int exchangeId = (int)ExchangeEnum.CryptoDotCom;
+            DateTime createdDate = DateTime.Now;
+
+            CreateMap<CryptoDotComBuyTransactionHistoryDto, Transaction>()
+                    .ForMember(dest => dest.AppUserId, opt => opt.MapFrom(src => appUserId))
+                    .ForMember(dest => dest.CryptoId, opt => opt.MapFrom<CryptoAssetResolver>())
+                    .ForMember(dest => dest.ExchangeTransactionTypeId, opt => opt.MapFrom<ExchangeTransactionTypeResolver>())
+                    .ForMember(dest => dest.FromExchangeId, opt => opt.MapFrom(src => exchangeId))
+                    .ForMember(dest => dest.CreatedDate, opt => opt.MapFrom(src => createdDate))
+                    ;
+        }
+
+    }
+}

--- a/AltFuture.BusinessLogicLayer/AutoMapper/Transactions/CryptoDotComRewardTransactionHitoryProfile.cs
+++ b/AltFuture.BusinessLogicLayer/AutoMapper/Transactions/CryptoDotComRewardTransactionHitoryProfile.cs
@@ -1,0 +1,27 @@
+﻿using AltFuture.BusinessLogicLayer.AutoMapper.Transactions.Resolvers;
+using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
+using AltFuture.DataAccessLayer.Data.Enums;
+using AltFuture.DataAccessLayer.Models;
+using AutoMapper;
+
+namespace AltFuture.BusinessLogicLayer.AutoMapper.Transactions
+{
+    public class CryptoDotComRewardTransactionHitoryProfile : Profile
+    {
+        public CryptoDotComRewardTransactionHitoryProfile()
+        {
+            int appUserId = 1;
+            int exchangeId = (int)ExchangeEnum.CryptoDotCom;
+            DateTime createdDate = DateTime.Now;
+
+            CreateMap<CryptoDotComRewardTransactionHistoryDto, Transaction>()
+                    .ForMember(dest => dest.AppUserId, opt => opt.MapFrom(src => appUserId))
+                    .ForMember(dest => dest.CryptoId, opt => opt.MapFrom<CryptoAssetResolver>())
+                    .ForMember(dest => dest.ExchangeTransactionTypeId, opt => opt.MapFrom<ExchangeTransactionTypeResolver>())
+                    .ForMember(dest => dest.FromExchangeId, opt => opt.MapFrom(src => exchangeId))
+                    .ForMember(dest => dest.CreatedDate, opt => opt.MapFrom(src => createdDate))
+                    ;
+        }
+
+    }
+}

--- a/AltFuture.BusinessLogicLayer/AutoMapper/Transactions/Resolvers/CryptoAssetResolver.cs
+++ b/AltFuture.BusinessLogicLayer/AutoMapper/Transactions/Resolvers/CryptoAssetResolver.cs
@@ -1,0 +1,23 @@
+﻿using AltFuture.DataAccessLayer.Models;
+using AutoMapper;
+using AltFuture.DataAccessLayer.Interfaces.Services;
+using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
+using AltFuture.BusinessLogicLayer.Interfaces.Models;
+
+namespace AltFuture.BusinessLogicLayer.AutoMapper.Transactions.Resolvers
+{
+    internal class CryptoAssetResolver : IValueResolver<IExchangeTransactionHistoryDto, Transaction, int>
+    {
+        private readonly List<Crypto> _cryptoLookup;
+
+        public CryptoAssetResolver(ICryptoDataService cryptoDataService)
+        {
+            _cryptoLookup = cryptoDataService.CryptoList;
+        }
+
+        public int Resolve(IExchangeTransactionHistoryDto source, Transaction destination, int destMember, ResolutionContext context)
+        {
+            return _cryptoLookup.FirstOrDefault(c => c.TickerSymbol == source.CryptoAsset).CryptoId;
+        }
+    }
+}

--- a/AltFuture.BusinessLogicLayer/AutoMapper/Transactions/Resolvers/ExchangeTransactionTypeResolver.cs
+++ b/AltFuture.BusinessLogicLayer/AutoMapper/Transactions/Resolvers/ExchangeTransactionTypeResolver.cs
@@ -1,0 +1,25 @@
+﻿using AltFuture.BusinessLogicLayer.Interfaces.Models;
+using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
+using AltFuture.DataAccessLayer.Data.Enums;
+using AltFuture.DataAccessLayer.Interfaces.Services;
+using AltFuture.DataAccessLayer.Models;
+using AutoMapper;
+
+namespace AltFuture.BusinessLogicLayer.AutoMapper.Transactions.Resolvers
+{
+    internal class ExchangeTransactionTypeResolver : IValueResolver<IExchangeTransactionHistoryDto, Transaction, int>
+    {
+        private readonly List<ExchangeTransactionType> _exchangeTransactionTypeLookup;
+
+        public ExchangeTransactionTypeResolver(IExchangeTransactionTypeDataService exchangeTransactionTypeDataService)
+        {
+            _exchangeTransactionTypeLookup = exchangeTransactionTypeDataService.ExchangeTransactionTypeList;
+        }
+
+        public int Resolve(IExchangeTransactionHistoryDto source, Transaction destination, int destMember, ResolutionContext context)
+        {
+            var exchangeId = (int)context.Items["ExchangeId"];
+            return _exchangeTransactionTypeLookup.FirstOrDefault(t => t.ExchangeId == exchangeId && t.ExchangeTransactionTypeName == source.ExchangeTransactionTypeName).ExchangeTransactionTypeId;
+        }
+    }
+}

--- a/AltFuture.BusinessLogicLayer/Interfaces/ITransactionCsvImports.cs
+++ b/AltFuture.BusinessLogicLayer/Interfaces/ITransactionCsvImports.cs
@@ -1,4 +1,5 @@
-﻿using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
+﻿using AltFuture.BusinessLogicLayer.Interfaces.Models;
+using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
 
 namespace AltFuture.BusinessLogicLayer.Interfaces
 {
@@ -6,5 +7,14 @@ namespace AltFuture.BusinessLogicLayer.Interfaces
     {
 
         Task<IEnumerable<CoinbaseTransactionHistoryDto>> ImportCoinbaseTransactionHistory(StreamReader reader);
+
+        Task<IEnumerable<T>> ImportExchangeTransactionHistory<T>(StreamReader reader) where T : IExchangeTransactionHistoryDto;
+        Task<IEnumerable<T>> ImportExchangeTransactionHistory<T>(StreamReader reader, int[]? transactionTypeFilter = null) where T : IExchangeTransactionHistoryDto;
+
+        Task<(IEnumerable<T1> type1Transactions, IEnumerable<T2> type2Transactions)> ImportExchangeTransactionHistory<T1, T2>(StreamReader reader,
+                                                                                                                              int exchageId,
+                                                                                                                              Dictionary<int, List<int>> transactionTypeFilter
+                                                                                                                             ) where T1 : IExchangeTransactionHistoryDto
+                                                                                                                               where T2 : IExchangeTransactionHistoryDto;
     }
 }

--- a/AltFuture.BusinessLogicLayer/Interfaces/Models/IExchangeTransactionHistoryDto.cs
+++ b/AltFuture.BusinessLogicLayer/Interfaces/Models/IExchangeTransactionHistoryDto.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AltFuture.BusinessLogicLayer.Interfaces.Models
+{
+    public interface IExchangeTransactionHistoryDto
+    {
+
+        public string? CryptoAsset { get; set; }
+
+        public string ExchangeTransactionTypeName { get; set; }
+
+        [Column(TypeName = "decimal(18,10)")]
+        [DefaultValue(0.00)]
+        public decimal Price { get; set; }
+
+        [Column(TypeName = "decimal(18,10)")]
+        [DefaultValue(0.00)]
+        public decimal Quantity { get; set; }
+
+        [Column(TypeName = "decimal(18,10)")]
+        [DefaultValue(0.00)]
+        public decimal Fee { get; set; }
+
+        [Column(TypeName = "decimal(18,10)")]
+        [DefaultValue(0.00)]
+        public decimal TransactionTotal { get; set; }
+
+        DateTime TransactionDate { get; set; }
+
+        
+
+        
+    }
+}

--- a/AltFuture.BusinessLogicLayer/Models/ExchangeTransactions/CryptoDotComBuyTransactionHistoryDto.cs
+++ b/AltFuture.BusinessLogicLayer/Models/ExchangeTransactions/CryptoDotComBuyTransactionHistoryDto.cs
@@ -1,0 +1,53 @@
+﻿using AltFuture.BusinessLogicLayer.Interfaces.Models;
+using CsvHelper.Configuration.Attributes;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
+
+
+namespace AltFuture.BusinessLogicLayer.Models.ExchangeTransactions
+{
+    public class CryptoDotComBuyTransactionHistoryDto : IExchangeTransactionHistoryDto
+    {
+        [Name("Timestamp (UTC)")]
+        public DateTime TransactionDate { get; set; }
+
+        [Name("Transaction Kind")]
+        public string ExchangeTransactionTypeName { get; set; }
+
+        [Name("To Currency")]
+        public string? CryptoAsset { get; set; } = null;
+
+
+        private decimal ignoreSetPrice = Decimal.Zero;
+        [Ignore]
+        public decimal Price { get => TransactionTotal / Quantity; set => ignoreSetPrice = value; }
+
+
+       // private decimal quantity = Decimal.Zero;
+        [Name("To Amount")]
+        [Default(defaultValue: 0)]
+        public decimal Quantity { get; set; } = Decimal.Zero;
+
+        [Ignore]
+        [Default(defaultValue: 0)]
+        public decimal Fee { get; set; } = Decimal.Zero;
+
+
+       // private decimal transactionTotal = Decimal.Zero;
+        [Name("Native Amount (in USD)")]
+        [Default(defaultValue: 0)]
+        public decimal TransactionTotal { get; set; }
+
+
+        [Name("Transaction Description")]
+        public string TransactionDescription { get; set; }
+
+
+
+        [Name("Transaction Hash")]
+        public string TransactionHash { get; set; }
+
+
+    }
+}

--- a/AltFuture.BusinessLogicLayer/Models/ExchangeTransactions/CryptoDotComRewardTransactionHistoryDto.cs
+++ b/AltFuture.BusinessLogicLayer/Models/ExchangeTransactions/CryptoDotComRewardTransactionHistoryDto.cs
@@ -1,0 +1,56 @@
+﻿using AltFuture.BusinessLogicLayer.Interfaces.Models;
+using CsvHelper.Configuration.Attributes;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
+
+
+namespace AltFuture.BusinessLogicLayer.Models.ExchangeTransactions
+{
+    public class CryptoDotComRewardTransactionHistoryDto : IExchangeTransactionHistoryDto
+    {
+        [Name("Timestamp (UTC)")]
+        public DateTime TransactionDate { get; set; }
+
+        [Name("Transaction Kind")]
+        public string ExchangeTransactionTypeName { get; set; }
+
+        [Name("Currency")]
+        public string? CryptoAsset { get; set; } = null;
+
+
+        [Ignore]
+        [Default(defaultValue: 0)]
+        public decimal Price { get; set; } = Decimal.Zero; //Value should always be zero for rewards
+
+
+        [Name("Amount")]
+        [Default(defaultValue: 0)]
+        public decimal Quantity { get; set; } = Decimal.Zero;
+
+        [Ignore]
+        [Default(defaultValue: 0)]
+        public decimal Fee { get; set; } = Decimal.Zero; //Value should always be zero for rewards
+
+
+        private decimal transactionTotal = Decimal.Zero;
+        [Name("Native Amount (in USD)")]
+        [Default(defaultValue: 0)]
+        public decimal TransactionTotal
+        { 
+            get => Quantity < 0 && transactionTotal > 0 ? transactionTotal * -1 : transactionTotal; 
+            set => transactionTotal = value; 
+        }
+
+
+        [Name("Transaction Description")]
+        public string TransactionDescription { get; set; }
+
+
+
+        [Name("Transaction Hash")]
+        public string TransactionHash { get; set; }
+
+
+    }
+}

--- a/AltFuture.BusinessLogicLayer/Models/ExchangeTransactions/CryptoDotComTransactionHistoryDto.cs
+++ b/AltFuture.BusinessLogicLayer/Models/ExchangeTransactions/CryptoDotComTransactionHistoryDto.cs
@@ -1,0 +1,54 @@
+﻿using AltFuture.BusinessLogicLayer.Interfaces.Models;
+using CsvHelper.Configuration.Attributes;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using System.ComponentModel.DataAnnotations.Schema;
+
+
+namespace AltFuture.BusinessLogicLayer.Models.ExchangeTransactions
+{
+    public class CryptoDotComTransactionHistoryDto : IExchangeTransactionHistoryDto
+    {
+        [Name("Timestamp (UTC)")]
+        public DateTime TransactionDate { get; set; }
+
+        [Name("Transaction Kind")]
+        public string ExchangeTransactionType { get; set; }
+
+        [Name("Transaction Description")]
+        public string TransactionDescription { get; set; }
+
+        public string Currency { get; set; }
+
+        [Column(TypeName = "decimal(18,10)")]
+        [Default(defaultValue: 0)]
+        public decimal Amount { get; set; } = decimal.Zero;
+
+        [Name("To Currency")]
+        public string ToCurrency { get; set; }
+
+        [Name("To Amount")]
+        [Column(TypeName = "decimal(18,10)")]
+        [Default(defaultValue:0)]
+        public decimal ToAmount { get; set; } = decimal.Zero;
+
+        [Name("Native Currency")]
+        public string NativeCurrency { get; set; }
+
+        [Name("Native Amount")]
+        [Column(TypeName = "decimal(18,10)")]
+        [Default(defaultValue: 0)]
+        public decimal NativeAmount { get; set; } = decimal.Zero;
+
+        [Name("Native Amount (in USD)")]
+        [Column(TypeName = "decimal(18,10)")]
+        [Default(defaultValue: 0)]
+        public decimal NativeAmountUsd { get; set; } = decimal.Zero;
+
+        [Name("Transaction Hash")]
+        public string TransactionHash { get; set; }
+
+        [Ignore]
+        public string? CryptoAsset { get; set; } = null;
+
+    }
+}

--- a/AltFuture.BusinessLogicLayer/Services/TransactionCsvImports.cs
+++ b/AltFuture.BusinessLogicLayer/Services/TransactionCsvImports.cs
@@ -3,11 +3,24 @@ using System.Globalization;
 using CsvHelper;
 using CsvHelper.Configuration;
 using AltFuture.BusinessLogicLayer.Models.ExchangeTransactions;
+using AltFuture.DataAccessLayer.Interfaces.Services;
+using AltFuture.DataAccessLayer.Models;
+using AltFuture.BusinessLogicLayer.Interfaces.Models;
 
 namespace AltFuture.BusinessLogicLayer.Services
 {
     public class TransactionCsvImports : ITransactionCsvImports
     {
+
+        private readonly List<ExchangeTransactionType> _exchangeTransactionTypeLookup;
+
+        public TransactionCsvImports(IExchangeTransactionTypeDataService exchangeTransactionTypeDataService)
+        {
+            _exchangeTransactionTypeLookup = exchangeTransactionTypeDataService.ExchangeTransactionTypeList;
+        }
+
+
+
         public async Task<IEnumerable<CoinbaseTransactionHistoryDto>> ImportCoinbaseTransactionHistory(StreamReader reader)
         {
             return await Task.Run(()=>
@@ -18,5 +31,82 @@ namespace AltFuture.BusinessLogicLayer.Services
                 return incomingTransactions;
             });
         }
+
+        public async Task<IEnumerable<T>> ImportExchangeTransactionHistory<T>(StreamReader reader) where T : IExchangeTransactionHistoryDto
+        {
+            return await Task.Run(() =>
+            {
+                using var csvReader = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture));
+                var incomingTransactions = csvReader.GetRecords<T>().ToList();
+
+                return incomingTransactions;
+            });
+        }
+
+
+        public async Task<IEnumerable<T>> ImportExchangeTransactionHistory<T>(StreamReader reader, int[]? transactionTypeFilter = null) where T : IExchangeTransactionHistoryDto
+        {
+            return await Task.Run(() =>
+            {
+
+                using var csvReader = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture));
+
+                var exchangeTransactionTypeFilter = _exchangeTransactionTypeLookup.Where(t => transactionTypeFilter.Contains(t.TransactionTypeId))
+                                                                                  .Select(t => t.ExchangeTransactionTypeName).ToList();
+
+                 var incomingTransactions = csvReader.GetRecords<T>().Where(t => exchangeTransactionTypeFilter.Contains(t.ExchangeTransactionTypeName)).ToList();
+
+                return incomingTransactions;
+            });
+        }
+
+        public async Task<(IEnumerable<T1> type1Transactions, IEnumerable<T2> type2Transactions)> ImportExchangeTransactionHistory<T1, T2>(StreamReader reader,
+                                                                                                                                           int exchageId,
+                                                                                                                                           Dictionary<int, List<int>> transactionTypeFilter
+                                                                                                                                          ) where T1 : IExchangeTransactionHistoryDto
+                                                                                                                                            where T2 : IExchangeTransactionHistoryDto
+        {
+            return await Task.Run(() =>
+            {
+                
+
+                var exchangeTransactionTypeFilter1 = _exchangeTransactionTypeLookup.Where(t => transactionTypeFilter[1].Contains(t.TransactionTypeId) 
+                                                                                               && t.ExchangeId == exchageId)
+                                                                                   .Select(t => t.ExchangeTransactionTypeName).ToList();
+
+                var exchangeTransactionTypeFilter2 = _exchangeTransactionTypeLookup.Where(t => transactionTypeFilter[2].Contains(t.TransactionTypeId) 
+                                                                                               && t.ExchangeId == exchageId)
+                                                                                   .Select(t => t.ExchangeTransactionTypeName).ToList();
+
+                var type1Transactions = new List<T1>();
+                var type2Transactions = new List<T2>();
+
+
+                using (var csvReader = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture)))
+                {
+                    csvReader.Read();
+                    csvReader.ReadHeader();
+
+                    while (csvReader.Read())
+                    {
+                        var exchangeTransactionType = csvReader.GetField("Transaction Kind");
+
+                        if (exchangeTransactionTypeFilter1.Contains(exchangeTransactionType))
+                        {
+                            var record = csvReader.GetRecord<T1>();
+                            type1Transactions.Add(record);
+                        }
+                        else if (exchangeTransactionTypeFilter2.Contains(exchangeTransactionType))
+                        {
+                            var record = csvReader.GetRecord<T2>();
+                            type2Transactions.Add(record);
+                        }
+                    }
+                }
+                return (type1Transactions, type2Transactions);
+
+            });
+        }
+
     }
 }

--- a/AltFuture.DataAccessLayer/Data/Configurations/ExchangeTransactionTypeConfiguration.cs
+++ b/AltFuture.DataAccessLayer/Data/Configurations/ExchangeTransactionTypeConfiguration.cs
@@ -49,7 +49,41 @@ namespace AltFuture.DataAccessLayer.Data.Configurations
                     ExchangeTransactionTypeId = 5,
                     ExchangeTransactionTypeName = "Learning Reward",
                     ExchangeId = (int)ExchangeEnum.Coinbase,
-                    TransactionTypeId = (int)TransactionTypeEnum.StakingReward,
+                    TransactionTypeId = (int)TransactionTypeEnum.PerkReward,
+                    DataImportTypeId = (int)DataImportTypeEnum.CSV
+                },
+
+                //Crypto.com CSV Transaction Types:
+                new ExchangeTransactionType
+                {
+                    ExchangeTransactionTypeId = 6,
+                    ExchangeTransactionTypeName = "viban_purchase",
+                    ExchangeId = (int)ExchangeEnum.CryptoDotCom,
+                    TransactionTypeId = (int)TransactionTypeEnum.Buy,
+                    DataImportTypeId = (int)DataImportTypeEnum.CSV
+                },
+                new ExchangeTransactionType
+                {
+                    ExchangeTransactionTypeId = 7,
+                    ExchangeTransactionTypeName = "reimbursement",
+                    ExchangeId = (int)ExchangeEnum.CryptoDotCom,
+                    TransactionTypeId = (int)TransactionTypeEnum.PerkReward,
+                    DataImportTypeId = (int)DataImportTypeEnum.CSV
+                },
+                new ExchangeTransactionType
+                {
+                    ExchangeTransactionTypeId = 8,
+                    ExchangeTransactionTypeName = "referral_card_cashback",
+                    ExchangeId = (int)ExchangeEnum.CryptoDotCom,
+                    TransactionTypeId = (int)TransactionTypeEnum.PerkReward,
+                    DataImportTypeId = (int)DataImportTypeEnum.CSV
+                },
+                new ExchangeTransactionType
+                {
+                    ExchangeTransactionTypeId = 9,
+                    ExchangeTransactionTypeName = "card_cashback_reverted",
+                    ExchangeId = (int)ExchangeEnum.CryptoDotCom,
+                    TransactionTypeId = (int)TransactionTypeEnum.PerkReward,
                     DataImportTypeId = (int)DataImportTypeEnum.CSV
                 }
 

--- a/AltFuture.DataAccessLayer/Data/Enums/ExchangeEnum.cs
+++ b/AltFuture.DataAccessLayer/Data/Enums/ExchangeEnum.cs
@@ -13,5 +13,7 @@ namespace AltFuture.DataAccessLayer.Data.Enums
         Coinbase = 1,
         [Display(Name = "Coinbase Pro")]
         CoinbasePro = 2,
+        [Display(Name = "Crypto.com")]
+        CryptoDotCom = 3,
     }
 }

--- a/AltFuture.DataAccessLayer/Data/Enums/TransactionTypeEnum.cs
+++ b/AltFuture.DataAccessLayer/Data/Enums/TransactionTypeEnum.cs
@@ -12,5 +12,8 @@ namespace AltFuture.DataAccessLayer.Data.Enums
         StakingReward = 4,
         [Display(Name = "Loan Interest")]
         LoanInterest = 5,
+        [Display(Name = "Perk Reward")]
+        PerkReward = 6,
+        Deposit = 7
     }
 }

--- a/AltFuture.DataAccessLayer/Migrations/20230331221201_TransactionTypeDataUpdate.Designer.cs
+++ b/AltFuture.DataAccessLayer/Migrations/20230331221201_TransactionTypeDataUpdate.Designer.cs
@@ -4,6 +4,7 @@ using AltFuture.DataAccessLayer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AltFuture.WebApp.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230331221201_TransactionTypeDataUpdate")]
+    partial class TransactionTypeDataUpdate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AltFuture.DataAccessLayer/Migrations/20230331221201_TransactionTypeDataUpdate.cs
+++ b/AltFuture.DataAccessLayer/Migrations/20230331221201_TransactionTypeDataUpdate.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace AltFuture.WebApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class TransactionTypeDataUpdate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "TransactionTypes",
+                columns: new[] { "TransactionTypeId", "TransactionTypeName" },
+                values: new object[,]
+                {
+                                { 6, "Perk Reward" },
+                                { 7, "Deposit" }
+                });
+
+            migrationBuilder.UpdateData(
+                table: "ExchangeTransactionTypes",
+                keyColumn: "ExchangeTransactionTypeId",
+                keyValue: 5,
+                column: "TransactionTypeId",
+                value: 6);
+
+            migrationBuilder.InsertData(
+                table: "Exchanges",
+                columns: new[] { "ExchangeId", "ExchangeName" },
+                values: new object[] { 3, "Crypto.com" });
+
+
+
+            migrationBuilder.InsertData(
+                table: "ExchangeTransactionTypes",
+                columns: new[] { "ExchangeTransactionTypeId", "DataImportTypeId", "ExchangeId", "ExchangeTransactionTypeName", "TransactionTypeId" },
+                values: new object[,]
+                {
+                    { 6, 2, 3, "viban_purchase", 1 },
+                    { 7, 2, 3, "reimbursement", 6 },
+                    { 8, 2, 3, "referral_card_cashback", 6 },
+                    { 9, 2, 3, "card_cashback_reverted", 6 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "ExchangeTransactionTypes",
+                keyColumn: "ExchangeTransactionTypeId",
+                keyValue: 5,
+                column: "TransactionTypeId",
+                value: 4);
+
+            migrationBuilder.DeleteData(
+                table: "ExchangeTransactionTypes",
+                keyColumn: "ExchangeTransactionTypeId",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                table: "ExchangeTransactionTypes",
+                keyColumn: "ExchangeTransactionTypeId",
+                keyValue: 7);
+
+            migrationBuilder.DeleteData(
+                table: "ExchangeTransactionTypes",
+                keyColumn: "ExchangeTransactionTypeId",
+                keyValue: 8);
+
+            migrationBuilder.DeleteData(
+                table: "ExchangeTransactionTypes",
+                keyColumn: "ExchangeTransactionTypeId",
+                keyValue: 9);
+
+            migrationBuilder.DeleteData(
+                table: "TransactionTypes",
+                keyColumn: "TransactionTypeId",
+                keyValue: 7);
+
+            migrationBuilder.DeleteData(
+                table: "Exchanges",
+                keyColumn: "ExchangeId",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "TransactionTypes",
+                keyColumn: "TransactionTypeId",
+                keyValue: 6);
+
+
+        }
+    }
+}

--- a/AltFuture.WebApp/Areas/Portfolios/Views/Dashboard/Index.cshtml
+++ b/AltFuture.WebApp/Areas/Portfolios/Views/Dashboard/Index.cshtml
@@ -1,6 +1,7 @@
 ﻿@using AltFuture.DataAccessLayer.Models.StoredProcs;
 @model IEnumerable<PortfolioSummaryGetAll>
 @{
+    ViewData["Title"] = "Portfolio Dashboard";
     var bodyData = Model.Where(crypto => crypto.RowType == 1).ToList();
     var footerData = Model.Where(crypto => crypto.RowType == 99).ToList()[0];
 }

--- a/AltFuture.WebApp/Areas/Portfolios/Views/TransactionImports/CryptoDotCom.cshtml
+++ b/AltFuture.WebApp/Areas/Portfolios/Views/TransactionImports/CryptoDotCom.cshtml
@@ -1,13 +1,13 @@
 ﻿
 @{
-    ViewData["Title"] = "Coinbase Transaction Import";
+    ViewData["Title"] = "Crypto.com Transaction Import";
 }
 
 
 <div class="container">
-    <h1 class="mt-4">Upload Coinbase CSV</h1>
+    <h1 class="mt-4">Upload Crypto.com CSV</h1>
 
-    <form asp-controller="TransactionImports" asp-action="Coinbase" method="post" enctype="multipart/form-data">
+    <form asp-controller="TransactionImports" asp-action="CryptoDotCom" method="post" enctype="multipart/form-data">
         <div class="form-group">
             <label for="csvFile">Choose CSV file</label>
             <input type="file" id="csvFile" name="csvFile" accept=".csv" class="form-control" required />

--- a/AltFuture.WebApp/Areas/Portfolios/Views/TransactionImports/Index.cshtml
+++ b/AltFuture.WebApp/Areas/Portfolios/Views/TransactionImports/Index.cshtml
@@ -1,7 +1,5 @@
-﻿@*
-    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-*@
-@{
+﻿@{
+    ViewData["Title"] = "Exchange Transaction Imports";
 }
 
 
@@ -10,7 +8,7 @@
         <a class="nav-link" asp-controller="TransactionImports" asp-action="Coinbase">Coinbase Import</a>
     </li>
     <li class="nav-item">
-        <a class="nav-link" asp-controller="TransactionImports" asp-action="Index">Crypto.com Import</a>
+        <a class="nav-link" asp-controller="TransactionImports" asp-action="CryptoDotCom">Crypto.com Import</a>
     </li>
     <li class="nav-item">
         <a class="nav-link" asp-controller="TransactionImports" asp-action="Index">Kucoin Import</a>

--- a/README.md
+++ b/README.md
@@ -199,3 +199,17 @@
 ### 3/30/2023
 - Moved PortfoliochartData service from DLL to BLL. It was in wrong layer.
 - Moved BLL.Models.DTOs.CoinbaseTransactionHistoryDto.cs to BLL.Models.ExchangeTransaction folder in prep for building out more Exchange Transaction import features.
+
+### 3/31/2023 - 4/2/2023
+- New CryptoDotCom Transaction History CSV Import feature.
+- The CSV data was not normalized and required specialized processing of records by "Buy" and "Reward" type subsets.
+- Created CryptoDotComBuyTransactionHistoryDto and CryptoDotComRewardTransactionHistoryDto objects to handle the mapping, calculations, and transfer of how the fields for both subset types needed to be processed.
+- Created an overloaded version of the ImportExchangeTransactionHistory method to accept in two generic types, restricted to be of interface type shared by DTOs, read and filter the CSV by subset type, and then return a touple of the two DTOs.
+- Created two AutoMapper profiles to map the DTOs into the entity model of Transaction.
+- Save all to the Transaction table.
+- Added needed Exchange, TransactionType, and ExchangeTransactionType data.
+- Migration"TransactionTypeDataUpdate"
+
+
+
+


### PR DESCRIPTION
- The CSV data was not normalized and required specialized processing of records by "Buy" and "Reward" type subsets.
- Created CryptoDotComBuyTransactionHistoryDto and CryptoDotComRewardTransactionHistoryDto objects to handle the mapping, calculations, and transfer of how the fields for both subset types needed to be processed.
- Created an overloaded version of the ImportExchangeTransactionHistory method to accept in two generic types, restricted to be of interface type shared by DTOs, read and filter the CSV by subset type, and then return a touple of the two DTOs.
- Created two AutoMapper profiles to map the DTOs into the entity model of Transaction.
- Save all to the Transaction table.
- Added needed Exchange, TransactionType, and ExchangeTransactionType data.
- Migration"TransactionTypeDataUpdate"