### PR TITLE
Added IsMonthStartPrice field to CryptoPrice

### DIFF
--- a/AltFuture.DataAccessLayer/Migrations/20230413182954_AlterCryptoPriceAddIsMonthStartPrice.Designer.cs
+++ b/AltFuture.DataAccessLayer/Migrations/20230413182954_AlterCryptoPriceAddIsMonthStartPrice.Designer.cs
@@ -4,6 +4,7 @@ using AltFuture.DataAccessLayer.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AltFuture.WebApp.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230413182954_AlterCryptoPriceAddIsMonthStartPrice")]
+    partial class AlterCryptoPriceAddIsMonthStartPrice
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AltFuture.DataAccessLayer/Migrations/20230413182954_AlterCryptoPriceAddIsMonthStartPrice.cs
+++ b/AltFuture.DataAccessLayer/Migrations/20230413182954_AlterCryptoPriceAddIsMonthStartPrice.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AltFuture.WebApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AlterCryptoPriceAddIsMonthStartPrice : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsMonthStartPrice",
+                table: "CryptoPrices",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsMonthStartPrice",
+                table: "CryptoPrices");
+        }
+    }
+}

--- a/AltFuture.DataAccessLayer/Models/CryptoPrice.cs
+++ b/AltFuture.DataAccessLayer/Models/CryptoPrice.cs
@@ -60,7 +60,8 @@ namespace AltFuture.DataAccessLayer.Models
         [DefaultValue(0.00)]
         public decimal MarketCapDominance { get; set; } = decimal.Zero;
 
-
+        [DefaultValue(false)]
+        public bool IsMonthStartPrice { get; set; } = false;
 
     }
 }

--- a/AltFuture.WebApp/Areas/Portfolios/Views/Dashboard/Index.cshtml
+++ b/AltFuture.WebApp/Areas/Portfolios/Views/Dashboard/Index.cshtml
@@ -24,7 +24,7 @@
     </div>
 </nav>
 
-<div class="container mt-4">
+<div class="container mt-4 mb-4">
     <div class="row">
         <div class="col-md-4">
             <!--Div for Asset Allocation Pie Chart-->
@@ -40,9 +40,10 @@
         </div>
     </div>
     <div class="row">
-        <div id="chartRunningTotal"></div>
+        <div class="col-12">
+            <div id="chartRunningTotal"></div>
+        </div>
     </div>
-
 </div>
 
 <div class="container mt-1">

--- a/README.md
+++ b/README.md
@@ -262,3 +262,9 @@
 - New SP - PortfolioRunningTotalByDay
 - New DbContext, Models, Repository updates
 - Added new Line Chart on Dashboard to show the KPI for monthly performance between investment and current worth.
+
+### 4/13/2023
+#### Added IsMonthStartPrice field to CryptoPrice
+- Note: I was going to build a feature to get historical prices using the CoinMarketCap API, but found that my data plan doesn't include access to historical data.
+- I just manually added the historical data I needed. 
+- Will have to re-visit in the future.


### PR DESCRIPTION
- Note: I was going to build a feature to get historical prices using the CoinMarketCap API, but found that my data plan doesn't include access to historical data.
- I just manually added the historical data I needed.
- Will have to re-visit in the future.